### PR TITLE
Requires user to set the repo endpoint url

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1
+current_version = 3.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/defs/main.tf
+++ b/defs/main.tf
@@ -1,7 +1,7 @@
 locals {
   skip_module   = "${var.salt_version == ""}"
   salt_versions = "${sort(distinct(concat(list(var.salt_version), var.extra_salt_versions)))}"
-  repo_prefix   = "${replace("${var.s3_endpoint}/${var.bucket_name}/${var.repo_prefix}", "/[/]$/", "")}"
+  repo_endpoint = "${replace(var.repo_endpoint, "/[/]*$/", "")}/${replace(var.repo_prefix, "/[/]*$/", "")}"
 }
 
 data "null_data_source" "amzn" {
@@ -9,8 +9,8 @@ data "null_data_source" "amzn" {
 
   inputs {
     name    = "salt-reposync-amzn"
-    baseurl = "${local.repo_prefix}/python2/amazon/latest/$basearch/archive/${local.salt_versions[count.index]}"
-    gpgkey  = "${local.repo_prefix}/python2/amazon/latest/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
+    baseurl = "${local.repo_endpoint}/python2/amazon/latest/$basearch/archive/${local.salt_versions[count.index]}"
+    gpgkey  = "${local.repo_endpoint}/python2/amazon/latest/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
   }
 }
 
@@ -19,8 +19,8 @@ data "null_data_source" "el6" {
 
   inputs {
     name    = "salt-reposync-el6"
-    baseurl = "${local.repo_prefix}/python2/redhat/6/$basearch/archive/${local.salt_versions[count.index]}"
-    gpgkey  = "${local.repo_prefix}/python2/redhat/6/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
+    baseurl = "${local.repo_endpoint}/python2/redhat/6/$basearch/archive/${local.salt_versions[count.index]}"
+    gpgkey  = "${local.repo_endpoint}/python2/redhat/6/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
   }
 }
 
@@ -29,8 +29,8 @@ data "null_data_source" "el7" {
 
   inputs {
     name    = "salt-reposync-el7"
-    baseurl = "${local.repo_prefix}/python2/redhat/7/$basearch/archive/${local.salt_versions[count.index]}"
-    gpgkey  = "${local.repo_prefix}/python2/redhat/7/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
+    baseurl = "${local.repo_endpoint}/python2/redhat/7/$basearch/archive/${local.salt_versions[count.index]}"
+    gpgkey  = "${local.repo_endpoint}/python2/redhat/7/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
   }
 }
 
@@ -39,8 +39,8 @@ data "null_data_source" "el7_python3" {
 
   inputs {
     name    = "salt-reposync-el7-python3"
-    baseurl = "${local.repo_prefix}/python3/7/$basearch/archive/${local.salt_versions[count.index]}"
-    gpgkey  = "${local.repo_prefix}/python3/7/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
+    baseurl = "${local.repo_endpoint}/python3/7/$basearch/archive/${local.salt_versions[count.index]}"
+    gpgkey  = "${local.repo_endpoint}/python3/7/$basearch/archive/${local.salt_versions[count.index]}/SALTSTACK-GPG-KEY.pub"
   }
 }
 
@@ -174,7 +174,7 @@ resource "null_resource" "push" {
   }
 
   triggers {
-    repo_prefix                    = "${local.repo_prefix}"
+    repo_endpoint                  = "${local.repo_endpoint}"
     salt_versions                  = "${join(",", local.salt_versions)}"
     s3_command                     = "${join(" ", local.s3_command)}"
     local_file.amzn                = "${md5(join("", local_file.amzn.*.content))}"

--- a/defs/variables.tf
+++ b/defs/variables.tf
@@ -11,6 +11,10 @@ variable "extra_salt_versions" {
   default = []
 }
 
+variable "repo_endpoint" {
+  type    = "string"
+}
+
 variable "repo_prefix" {
   type    = "string"
   default = ""
@@ -19,11 +23,6 @@ variable "repo_prefix" {
 variable "yum_prefix" {
   type    = "string"
   default = ""
-}
-
-variable "s3_endpoint" {
-  type    = "string"
-  default = "https://s3.amazonaws.com"
 }
 
 variable "cache_dir" {

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,8 @@ module "yum_defs" {
   bucket_name         = "${var.bucket_name}"
   salt_version        = "${var.salt_version}"
   extra_salt_versions = "${var.extra_salt_versions}"
+  repo_endpoint       = "${var.repo_endpoint}"
   repo_prefix         = "${var.repo_prefix}"
   yum_prefix          = "${var.yum_prefix}"
-  s3_endpoint         = "${var.s3_endpoint}"
   cache_dir           = "${var.cache_dir}/defs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@ variable "extra_salt_versions" {
   default     = []
 }
 
+variable "repo_endpoint" {
+  type        = "string"
+  description = "HTTP/S endpoint URL that hosts the yum repos; used with the baseurl in the yum .repo definitions"
+}
+
 variable "repo_prefix" {
   type        = "string"
   description = "S3 key where the repos will be mirrored"
@@ -30,12 +35,6 @@ variable "salt_rsync_url" {
   type        = "string"
   description = "rsync URL to the upstream yum repo"
   default     = "rsync://rsync.repo.saltstack.com/saltstack_pkgrepo_rhel"
-}
-
-variable "s3_endpoint" {
-  type        = "string"
-  description = "HTTP/S endpoint for S3"
-  default     = "https://s3.amazonaws.com"
 }
 
 variable "cache_dir" {


### PR DESCRIPTION
The repo endpoint is used to construct the baseurl in the yum
repo definitions. Previously it was assumed the endpoint would
always be S3. However, it is useful to front S3 with Cloudfront
or another CDN, at which point the endpoint can be most any URL.

To restore the prior behavior, set:

```
repo_endpoint = <s3_endpoint>/<bucket_name>
```