### PR TITLE
Replaces the deprecated list() with []

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.1
+current_version = 5.0.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/repo/main.tf
+++ b/modules/repo/main.tf
@@ -25,18 +25,18 @@ locals {
 
   rclone_python2 = concat(
     local.rclone_base,
-    list(
+    [
       "salt:s3/yum",             # rclone source
       "s3:${var.bucket_name}/%s" # rclone target, %s is repo.repo_prefix_python2
-    )
+    ]
   )
 
   rclone_python3 = concat(
     local.rclone_base,
-    list(
+    [
       "salt:s3/py3",             # rclone source
       "s3:${var.bucket_name}/%s" # rclone target, %s is repo.repo_prefix_python3
-    )
+    ]
   )
 }
 


### PR DESCRIPTION
Results of `make test`:

```
PASS
ok      tardigrade-ci/tests     1383.142s
[terratest/test]: Completed successfully!
```