### PR TITLE
Remove rclone install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ tardigrade-ci
 
 # Cache created by pytest
 tests/__pycache__/
+
+#ide folders
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,3 @@
 SHELL := /bin/bash
 
 include $(shell test -f .tardigrade-ci || curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/plus3it/tardigrade-ci/master/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)
-
-## Install rclone
-rclone/install: RCLONE_VERSION ?= latest
-rclone/install: $(BIN_DIR) guard/program/unzip
-	@ echo "[$@]: Installing $(@D)..."
-	$(call download_github_release,$(@D).zip,$(@D),$(@D),$(RCLONE_VERSION),.name | endswith("$(OS)-$(ARCH).zip"))
-	unzip $(@D).zip
-	mv $(@D)-*/$(@D) $(BIN_DIR)
-	rm -rf $(@D)*
-	chmod +x $(BIN_DIR)/$(@D)
-	$(@D) --version


### PR DESCRIPTION
Once the tardigrade-ci rclone/install target is merged into master the rclone/install in this Makefile is no longer necessary.