### PR TITLE
Adds feature to specify the source bucket name for the rclone command

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.3
+current_version = 6.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | S3 bucket where salt repo will be mirrored | `string` | n/a | yes |
 | <a name="input_repo_endpoint"></a> [repo\_endpoint](#input\_repo\_endpoint) | HTTP/S endpoint URL that hosts the yum repos; used with the baseurl in the yum .repo definitions | `string` | n/a | yes |
-| <a name="input_repos"></a> [repos](#input\_repos) | Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror. `yum_prefix` is the S3 key prefix for the yum repo definition files. | <pre>list(object({<br>    repo_prefix      = string<br>    salt_s3_endpoint = string<br>    salt_versions    = list(string)<br>    yum_prefix       = string<br>  }))</pre> | n/a | yes |
+| <a name="input_repos"></a> [repos](#input\_repos) | Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_bucket` is the name of s3 bucket; typically "s3" when using a cloudfront endpoint. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror. `yum_prefix` is the S3 key prefix for the yum repo definition files. | <pre>list(object({<br>    repo_prefix      = string<br>    salt_s3_bucket   = string<br>    salt_s3_endpoint = string<br>    salt_versions    = list(string)<br>    yum_prefix       = string<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/defs/main.tf
+++ b/modules/defs/main.tf
@@ -39,7 +39,7 @@ locals {
   ])
 }
 
-resource "aws_s3_bucket_object" "this" {
+resource "aws_s3_object" "this" {
   for_each = { for repo_def in local.repo_defs : repo_def.key => repo_def.content }
 
   bucket       = var.bucket_name

--- a/modules/repo/README.md
+++ b/modules/repo/README.md
@@ -19,7 +19,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | n/a | `string` | n/a | yes |
-| <a name="input_repos"></a> [repos](#input\_repos) | Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror. | <pre>list(object({<br>    repo_prefix      = string<br>    salt_s3_endpoint = string<br>    salt_versions    = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_repos"></a> [repos](#input\_repos) | Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_bucket` is the name of s3 bucket; typically "s3" when using a cloudfront endpoint. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror. | <pre>list(object({<br>    repo_prefix      = string<br>    salt_s3_bucket   = string<br>    salt_s3_endpoint = string<br>    salt_versions    = list(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/repo/main.tf
+++ b/modules/repo/main.tf
@@ -4,6 +4,7 @@ locals {
       id                  = "${repo.salt_s3_endpoint}_${repo.repo_prefix}"
       repo_prefix_python2 = "${trim(repo.repo_prefix, "/")}/python2"
       repo_prefix_python3 = "${trim(repo.repo_prefix, "/")}/python3"
+      salt_s3_bucket      = repo.salt_s3_bucket
       salt_s3_endpoint    = repo.salt_s3_endpoint
       salt_versions       = formatlist("--filter '+ {amazon,redhat}/{latest,?}/**/archive/%s/**'", sort(repo.salt_versions))
     }
@@ -24,7 +25,7 @@ locals {
   rclone_python2 = concat(
     local.rclone_base,
     [
-      "salt:s3/yum",                            # rclone source
+      "salt:%s/yum",                            # rclone source, %s is repo.salt_s3_bucket
       ":s3,env_auth=true:${var.bucket_name}/%s" # rclone target, %s is repo.repo_prefix_python2
     ]
   )
@@ -32,7 +33,7 @@ locals {
   rclone_python3 = concat(
     local.rclone_base,
     [
-      "salt:s3/py3",                            # rclone source
+      "salt:%s/py3",                            # rclone source, %s is repo.salt_s3_bucket
       ":s3,env_auth=true:${var.bucket_name}/%s" # rclone target, %s is repo.repo_prefix_python3
     ]
   )
@@ -46,6 +47,7 @@ resource "null_resource" "sync_python2" {
       join(" ", local.rclone_python2),
       each.value.salt_s3_endpoint,
       join(" ", each.value.salt_versions),
+      each.value.salt_s3_bucket,
       each.value.repo_prefix_python2,
     )
   }
@@ -55,6 +57,7 @@ resource "null_resource" "sync_python2" {
       join(" ", local.rclone_python2),
       each.value.salt_s3_endpoint,
       join(" ", each.value.salt_versions),
+      each.value.salt_s3_bucket,
       each.value.repo_prefix_python2,
     )
   }
@@ -68,6 +71,7 @@ resource "null_resource" "sync_python3" {
       join(" ", local.rclone_python3),
       each.value.salt_s3_endpoint,
       join(" ", each.value.salt_versions),
+      each.value.salt_s3_bucket,
       each.value.repo_prefix_python3,
     )
   }
@@ -77,6 +81,7 @@ resource "null_resource" "sync_python3" {
       join(" ", local.rclone_python3),
       each.value.salt_s3_endpoint,
       join(" ", each.value.salt_versions),
+      each.value.salt_s3_bucket,
       each.value.repo_prefix_python3,
     )
   }

--- a/modules/repo/variables.tf
+++ b/modules/repo/variables.tf
@@ -3,9 +3,10 @@ variable "bucket_name" {
 }
 
 variable "repos" {
-  description = "Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror."
+  description = "Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_bucket` is the name of s3 bucket; typically \"s3\" when using a cloudfront endpoint. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror."
   type = list(object({
     repo_prefix      = string
+    salt_s3_bucket   = string
     salt_s3_endpoint = string
     salt_versions    = list(string)
   }))

--- a/tests/main/main.tf
+++ b/tests/main/main.tf
@@ -16,22 +16,21 @@ module "main" {
       repo_prefix      = local.repo_prefix
       yum_prefix       = local.yum_prefix
     },
-    # Commented out because this endpoint is currently broken
-    # {
-    #   # Test using cloudfront endpoint for archive repo
-    #   salt_s3_bucket   = local.salt_s3_bucket
-    #   salt_s3_endpoint = local.salt_s3_endpoint_archive
-    #   salt_versions    = local.salt_versions_archive
-    #   repo_prefix      = local.repo_prefix_archive
-    #   yum_prefix       = local.yum_prefix
-    # },
+    {
+      # Test using cloudfront endpoint for archive repo
+      salt_s3_bucket   = local.salt_s3_bucket
+      salt_s3_endpoint = local.salt_s3_endpoint_archive
+      salt_versions    = local.salt_versions_archive
+      repo_prefix      = local.repo_prefix_archive
+      yum_prefix       = local.yum_prefix
+    },
     {
       # Test using the underlying archive bucket directly, instead of cloudfront
       salt_s3_bucket   = "archive-repo-saltstack-com"
       salt_s3_endpoint = "s3.us-west-2.amazonaws.com"
       salt_versions    = local.salt_versions_archive
       repo_prefix      = "repo/underlying_bucket/"
-      yum_prefix       = local.yum_prefix
+      yum_prefix       = "${local.yum_prefix}/underlying_bucket/"
     },
   ]
 }

--- a/tests/main/main.tf
+++ b/tests/main/main.tf
@@ -9,15 +9,28 @@ module "main" {
   repo_endpoint = local.repo_endpoint
   repos = [
     {
-      yum_prefix       = local.yum_prefix
+      # Test using cloudfront endpoint for main repo
+      salt_s3_bucket   = local.salt_s3_bucket
       salt_s3_endpoint = local.salt_s3_endpoint
       salt_versions    = local.salt_versions
       repo_prefix      = local.repo_prefix
+      yum_prefix       = local.yum_prefix
     },
+    # Commented out because this endpoint is currently broken
+    # {
+    #   # Test using cloudfront endpoint for archive repo
+    #   salt_s3_bucket   = local.salt_s3_bucket
+    #   salt_s3_endpoint = local.salt_s3_endpoint_archive
+    #   salt_versions    = local.salt_versions_archive
+    #   repo_prefix      = local.repo_prefix_archive
+    #   yum_prefix       = local.yum_prefix
+    # },
     {
-      repo_prefix      = local.repo_prefix_archive
-      salt_s3_endpoint = local.salt_s3_endpoint_archive
+      # Test using the underlying archive bucket directly, instead of cloudfront
+      salt_s3_bucket   = "archive-repo-saltstack-com"
+      salt_s3_endpoint = "s3.us-west-2.amazonaws.com"
       salt_versions    = local.salt_versions_archive
+      repo_prefix      = "repo/underlying_bucket/"
       yum_prefix       = local.yum_prefix
     },
   ]
@@ -33,12 +46,13 @@ locals {
   repo_endpoint            = "https://${aws_s3_bucket.this.bucket_regional_domain_name}"
   repo_prefix              = "repo/main/"
   repo_prefix_archive      = "repo/archive/"
-  salt_s3_endpoint         = "https://s3.repo.saltstack.com"
-  salt_s3_endpoint_archive = "https://s3.archive.repo.saltstack.com"
+  salt_s3_bucket           = "s3"
+  salt_s3_endpoint         = "https://s3.repo.saltproject.io"
+  salt_s3_endpoint_archive = "https://s3.archive.repo.saltproject.io"
   yum_prefix               = "defs/"
 
   salt_versions = [
-    "3002",
+    "3004.2",
   ]
 
   salt_versions_archive = [

--- a/tests/repo/main.tf
+++ b/tests/repo/main.tf
@@ -14,14 +14,13 @@ module "repo" {
       salt_versions    = local.salt_versions
       repo_prefix      = local.repo_prefix
     },
-    # Commented out because this endpoint is currently broken
-    # {
-    #   # Test using cloudfront endpoint for archive repo
-    #   salt_s3_bucket   = local.salt_s3_bucket
-    #   salt_s3_endpoint = local.salt_s3_endpoint_archive
-    #   salt_versions    = local.salt_versions_archive
-    #   repo_prefix      = local.repo_prefix_archive
-    # },
+    {
+      # Test using cloudfront endpoint for archive repo
+      salt_s3_bucket   = local.salt_s3_bucket
+      salt_s3_endpoint = local.salt_s3_endpoint_archive
+      salt_versions    = local.salt_versions_archive
+      repo_prefix      = local.repo_prefix_archive
+    },
     {
       # Test using the underlying archive bucket directly, instead of cloudfront
       salt_s3_bucket   = "archive-repo-saltstack-com"

--- a/tests/repo/main.tf
+++ b/tests/repo/main.tf
@@ -8,14 +8,26 @@ module "repo" {
   bucket_name = local.bucket_name
   repos = [
     {
+      # Test using cloudfront endpoint for main repo
+      salt_s3_bucket   = local.salt_s3_bucket
       salt_s3_endpoint = local.salt_s3_endpoint
       salt_versions    = local.salt_versions
       repo_prefix      = local.repo_prefix
     },
+    # Commented out because this endpoint is currently broken
+    # {
+    #   # Test using cloudfront endpoint for archive repo
+    #   salt_s3_bucket   = local.salt_s3_bucket
+    #   salt_s3_endpoint = local.salt_s3_endpoint_archive
+    #   salt_versions    = local.salt_versions_archive
+    #   repo_prefix      = local.repo_prefix_archive
+    # },
     {
-      salt_s3_endpoint = local.salt_s3_endpoint_archive
+      # Test using the underlying archive bucket directly, instead of cloudfront
+      salt_s3_bucket   = "archive-repo-saltstack-com"
+      salt_s3_endpoint = "s3.us-west-2.amazonaws.com"
       salt_versions    = local.salt_versions_archive
-      repo_prefix      = local.repo_prefix_archive
+      repo_prefix      = "repo/underlying_bucket/"
     },
   ]
 }
@@ -29,11 +41,12 @@ locals {
   bucket_name              = aws_s3_bucket.this.id
   repo_prefix              = "repo/main/"
   repo_prefix_archive      = "repo/archive/"
-  salt_s3_endpoint         = "https://s3.repo.saltstack.com"
-  salt_s3_endpoint_archive = "https://s3.archive.repo.saltstack.com"
+  salt_s3_bucket           = "s3"
+  salt_s3_endpoint         = "https://s3.repo.saltproject.io"
+  salt_s3_endpoint_archive = "https://s3.archive.repo.saltproject.io"
 
   salt_versions = [
-    "3002",
+    "3004.2",
   ]
 
   salt_versions_archive = [

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,10 @@ variable "repo_endpoint" {
 }
 
 variable "repos" {
-  description = "Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror. `yum_prefix` is the S3 key prefix for the yum repo definition files."
+  description = "Schema list of repo objects. `repo_prefix` is the S3 key prefix where the repo will be mirrored. `salt_s3_bucket` is the name of s3 bucket; typically \"s3\" when using a cloudfront endpoint. `salt_s3_endpoint` is the upstream s3 endpoint hosting the repos. `salt_versions` is the list of salt versions to mirror. `yum_prefix` is the S3 key prefix for the yum repo definition files."
   type = list(object({
     repo_prefix      = string
+    salt_s3_bucket   = string
     salt_s3_endpoint = string
     salt_versions    = list(string)
     yum_prefix       = string


### PR DESCRIPTION
The cloudfront cache in front of the salt archive repo is currently
experiencing some issues that prevent the bucket listing from working
correctly. This patchset provides an option for setting the "bucket name"
in the rclone command, so the user can hit the underlying s3 bucket
directly, instead of going through cloudfront.

It is unfortunate that this is backwards-incompatible, in that due
to the way terraform objects work, the user *must* add the new attribute
to their input objects.